### PR TITLE
typo: utilities method boolToStr

### DIFF
--- a/lib/adLDAP/classes/adLDAPExchange.php
+++ b/lib/adLDAP/classes/adLDAPExchange.php
@@ -80,7 +80,7 @@ class adLDAPExchange {
         if ($mailNickname === NULL) { 
             $mailNickname = $username; 
         }
-        $mdbUseDefaults = $this->adldap->utilities()->boolToString($useDefaults);
+        $mdbUseDefaults = $this->adldap->utilities()->boolToStr($useDefaults);
         
         $attributes = array(
             'exchange_homemdb'=>$container.",".$baseDn,


### PR DESCRIPTION
There are no method boolToString in adLDAPUtils, should be boolToStr.
