### PR TITLE
Time conversion problem

### DIFF
--- a/lib/adLDAP/classes/adLDAPUtils.php
+++ b/lib/adLDAP/classes/adLDAPUtils.php
@@ -256,7 +256,7 @@ class adLDAPUtils {
     * @return long $unixTime
     */
     public static function convertWindowsTimeToUnixTime($windowsTime) {
-      $unixTime = round($windowsTime / 10000000) - 11644477200; 
+      $unixTime = round($windowsTime / 10000000) - 11644473600; 
       return $unixTime; 
     }
 


### PR DESCRIPTION
The difference between 1601-01-01 and 1970-01-01 was one hour too much.
