### PR TITLE
Add isset check on $entries[$i]["description"]

### DIFF
--- a/lib/adLDAP/classes/adLDAPGroups.php
+++ b/lib/adLDAP/classes/adLDAPGroups.php
@@ -558,7 +558,7 @@ class adLDAPGroups {
 
         $groupsArray = array();        
         for ($i=0; $i<$entries["count"]; $i++) {
-            if ($includeDescription && strlen($entries[$i]["description"][0]) > 0 ) {
+            if ($includeDescription && isset($entries[$i]["description"]) && strlen($entries[$i]["description"][0]) > 0 ) {
                 $groupsArray[$entries[$i]["samaccountname"][0]] = $entries[$i]["description"][0];
             }
             else if ($includeDescription) {


### PR DESCRIPTION
I was using your library (it's a great tool BTW) and came across this exception while using the $adLDAP->groups()->all() method.

exception 'ErrorException' with message 'Undefined index: description'

To fix this error, I added a conditional to the if clause that was searching for data in $entries[$i]["description"]. I figured I might pass this on in case it is helpful to others.