### PR TITLE
Using escape characters while searching

### DIFF
--- a/lib/adLDAP/classes/adLDAPGroups.php
+++ b/lib/adLDAP/classes/adLDAPGroups.php
@@ -349,6 +349,8 @@ class adLDAPGroups {
     * @param bool $recursive Recursively get group members
     * @return array
     */
+    protected $groupsDone = array();
+    
     public function members($group, $recursive = NULL) {
         if (!$this->adldap->getLdapBind()) { return false; }
         if ($recursive === NULL){ $recursive = $this->adldap->getRecursiveGroups(); } // Use the default option if they haven't set it 
@@ -361,7 +363,9 @@ class adLDAPGroups {
  
         $userArray = array();
 
-        for ($i=0; $i<$users["count"]; $i++) { 
+        for ($i=0; $i<$users["count"]; $i++) {
+             if (in_array($users[$i], $this->groupsDone)) continue;
+             $this->groupsDone[] = $users[$i];
              $filter = "(&(objectCategory=person)(distinguishedName=" . $this->adldap->utilities()->ldapSlashes($users[$i]) . "))";
              $fields = array("samaccountname", "distinguishedname", "objectClass");
              $sr = ldap_search($this->adldap->getLdapConnection(), $this->adldap->getBaseDn(), $filter, $fields);

--- a/lib/adLDAP/classes/adLDAPGroups.php
+++ b/lib/adLDAP/classes/adLDAPGroups.php
@@ -516,7 +516,7 @@ class adLDAPGroups {
         if ($sAMAaccountType !== null) {
             $filter .= '(samaccounttype='. $sAMAaccountType .')';
         }
-        $filter .= '(cn=' . $search . '))';
+        $filter .= '(cn=' . $this->adldap->utilities()->ldapSlashes($search) . '))';
         // Perform the search and grab all their details
         $fields = array("samaccountname", "description");
         $sr = ldap_search($this->adldap->getLdapConnection(), $this->adldap->getBaseDn(), $filter, $fields);


### PR DESCRIPTION
Without the escape method groups with rounded brackets gave me an LDAP error. Thanks 'HS' for letting me know about this bug.
