### PR TITLE
Quickfix for Undefined Offset notice

### DIFF
--- a/src/Objects/Ldap/Entry.php
+++ b/src/Objects/Ldap/Entry.php
@@ -48,7 +48,7 @@ class Entry extends AbstractObject
                     if (array_key_exists('count', $attributes[$key]) && $attributes[$key]['count'] > 1) {
                         $data = [];
 
-                        for ($i = 0; $i <= $attributes[$key]['count']; $i++) {
+                        for ($i = 0; $i < $attributes[$key]['count']; $i++) {
                             $data[] = $attributes[$key][$i];
                         }
 


### PR DESCRIPTION
Uses `<` instead of `<=` in the `for` loop within `Entry::applyAttributes`
to prevent an Undefined Offset notice from being thrown.
