### PR TITLE
Fix off by one. Issue #82

### DIFF
--- a/src/Objects/Ldap/Entry.php
+++ b/src/Objects/Ldap/Entry.php
@@ -48,7 +48,7 @@ class Entry extends AbstractObject
                     if (array_key_exists('count', $attributes[$key]) && $attributes[$key]['count'] > 1) {
                         $data = [];
 
-                        for ($i = 0; $i <= $attributes[$key]['count']; $i++) {
+                        for ($i = 0; $i < $attributes[$key]['count']; $i++) {
                             $data[] = $attributes[$key][$i];
                         }
 


### PR DESCRIPTION
Fixes a problem where it loops one item more than it needs to, for every $key in $attributes. This leads into an invalid offset notice for every attribute.
