### PR TITLE
Fixed a bug.

### DIFF
--- a/src/Objects/Ldap/Entry.php
+++ b/src/Objects/Ldap/Entry.php
@@ -49,7 +49,7 @@ class Entry extends AbstractObject
                         $data = [];
 
                         for ($i = 0; $i <= $attributes[$key]['count']; $i++) {
-                            $data[] = $attributes[$key][$i];
+                            if(isset($attributes[$key][$i])) $data[] = $attributes[$key][$i];
                         }
 
                         $this->setAttribute($key, array_filter($data));


### PR DESCRIPTION
In Entry::applyExtraAttributes(), the class will falsely attempt to apply attributes that do not exist resulting in a number of PHP errors. An if isset() condition was added to skip the attemtpt to add it to the data[] array if the array element in question does not exist.