### PR TITLE
Support LDAP_OPT_DIAGNOSTIC_MESSAGE

### DIFF
--- a/src/Adldap.php
+++ b/src/Adldap.php
@@ -2,6 +2,7 @@
 
 namespace Adldap;
 
+use Adldap\Classes\AdldapError;
 use Adldap\Exceptions\AdldapException;
 use Adldap\Interfaces\ConnectionInterface;
 use Adldap\Classes\AdldapSearch;
@@ -822,7 +823,14 @@ class Adldap
      * This may indeed be a 'Success' message but if you get an unknown error
      * it might be worth calling this function to see what errors were raised
      *
-     * @return string
+     * Note that this will usually return a string, unless setExtendedErrors()
+     * has been called on Connection\Ldap
+     *
+     * When setExtendedErrors has been set, this will return false if the last
+     * request completed successfully. If not, it will return a new instance of
+     * AdldapError.
+     * 
+     * @return bool|string|AdldapError
      */
     public function getLastError()
     {

--- a/src/Classes/AdldapError.php
+++ b/src/Classes/AdldapError.php
@@ -1,0 +1,51 @@
+<?php
+namespace Adldap\Classes;
+
+class AdldapError
+{
+    /**
+     * @var int the error code from ldap_errno
+     */
+    private $errorCode = null;
+
+    /**
+     * @var string the error message from ldap_error
+     */
+    private $errorMessage = null;
+
+    /**
+     * @var string the diagnostic message when retrieved after an ldap_error
+     */
+    private $diagnosticMessage = null;
+
+    public function __construct($errorCode, $errorMessage, $diagnosticMessage)
+    {
+        $this->errorCode = $errorCode;
+        $this->errorMessage = $errorMessage;
+        $this->diagnosticMessage;
+    }
+
+    /**
+     * @return int
+     */
+    public function getErrorCode()
+    {
+        return $this->errorCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrorMessage()
+    {
+        return $this->errorMessage;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDiagnosticMessage()
+    {
+        return $this->diagnosticMessage;
+    }
+}


### PR DESCRIPTION
Add a new piece of functionality to support retrieving extended LDAP diagnostic messages.

```
$adldap->getConnection()->setExtendedErrors();
$result = $adldap->user()->create($attributes);

if (!$result) {
     $error = $adldap->getLastError();
     echo "There was an error adding a user: " . $error->getDiagnosticMessage();
}
```