### PR TITLE
Bugfix for undefined array index error when getting ldap groups for a…

### DIFF
--- a/src/Objects/Ldap/Entry.php
+++ b/src/Objects/Ldap/Entry.php
@@ -48,7 +48,7 @@ class Entry extends AbstractObject
                     if (array_key_exists('count', $attributes[$key]) && $attributes[$key]['count'] > 1) {
                         $data = [];
 
-                        for ($i = 0; $i <= $attributes[$key]['count']; $i++) {
+                        for ($i = 0; $i < $attributes[$key]['count']; $i++) {
                             $data[] = $attributes[$key][$i];
                         }
 


### PR DESCRIPTION
This is a bugfix for an undefined array index error which occurs when retrieving ldap groups for an ldap user.  